### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,13 +34,13 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |
@@ -51,7 +51,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.2](https://github.com/actions/checkout/releases/tag/v3.5.2)** on 2023-04-13T12:49:40Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.1](https://github.com/actions/cache/releases/tag/v3.3.1)** on 2023-03-13T05:05:19Z
* **[r-lib/actions](https://github.com/r-lib/actions)** published a new release **[v2](https://github.com/r-lib/actions/releases/tag/v2)** on 2021-12-12T17:39:09Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.2](https://github.com/actions/upload-artifact/releases/tag/v3.1.2)** on 2023-01-06T14:29:05Z
